### PR TITLE
Fix reporting success on for non 4xx, 5xx HTTP statuses

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,9 @@ key=$3
 image=$4
 tag=$5
 
-curl -s -o /dev/null \
+curl \
+-s \
+-o /dev/null \
 --location "$host/v1-webhooks/endpoint?key=$key&projectId=$projectId" \
 --header 'Content-Type: application/json' \
 --header 'Cookie: PL=rancher' \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,9 +27,9 @@ http_status_code=$(curl \
     }
 }')
 
-status=$?
+curl_exit_code=$?
 
-if [ $status -eq 0 ]; then
+if [ $curl_exit_code -eq 0 ]; then
     echo "curl was successful."
     if expr "${http_status_code}" : '[45]..$' 1>/dev/null; then
         echo "Webhook failed with status code ${http_status_code}."
@@ -37,5 +37,5 @@ if [ $status -eq 0 ]; then
         echo "Webhook was triggered successfully."
     fi
 else
-    echo "curl failed with status code $status."
+    echo "curl failed with exit code $curl_exit_code."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ tag=$5
 
 curl \
 --silent \
--o /dev/null \
+--output /dev/null \
 --location "$host/v1-webhooks/endpoint?key=$key&projectId=$projectId" \
 --header 'Content-Type: application/json' \
 --header 'Cookie: PL=rancher' \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,25 +11,31 @@ key=$3
 image=$4
 tag=$5
 
-curl \
---silent \
---output /dev/null \
---location "$host/v1-webhooks/endpoint?key=$key&projectId=$projectId" \
---header 'Content-Type: application/json' \
---header 'Cookie: PL=rancher' \
---data '{
+http_status_code=$(curl \
+  --silent \
+  --output /dev/null \
+  --write-out '%{http_code}' \
+  --location "$host/v1-webhooks/endpoint?key=$key&projectId=$projectId" \
+  --header 'Content-Type: application/json' \
+  --header 'Cookie: PL=rancher' \
+  --data '{
     "push_data": {
         "tag": "'"$tag"'"
     },
     "repository": {
         "repo_name": "'"$image"'"
     }
-}'
+}')
 
 status=$?
 
 if [ $status -eq 0 ]; then
-    echo "curl was successful (HTTP Status 200 OK)."
+    echo "curl was successful."
+    if expr "${http_status_code}" : '[45]..$' 1>/dev/null; then
+        echo "Webhook failed with status code ${http_status_code}."
+    else
+        echo "Webhook was triggered successfully."
+    fi
 else
     echo "curl failed with status code $status."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ image=$4
 tag=$5
 
 curl \
--s \
+--silent \
 -o /dev/null \
 --location "$host/v1-webhooks/endpoint?key=$key&projectId=$projectId" \
 --header 'Content-Type: application/json' \


### PR DESCRIPTION
Before this PR, Please merge my other PR with long parameter names for `curl`.

In this PR I want to clarify the reporting and show `Webhook failed with status code ${http_status_code}.` for HTTP 4XX and 5XX codes. The other codes show the "Webhook was triggered successfully."